### PR TITLE
Patch Ethers V5 beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 - ...
 
+## `1.3.3` - 05/14/2020
+
+#### Fixed
+
+- Fix a bug affecting Ethers JS V5 beta that would fail to attach the required ID parameter to JSON RPC 2.0 request payloads.
+
 ## `1.3.2` - 05/07/2020
 
 #### Fixed

--- a/src/core/json-rpc.ts
+++ b/src/core/json-rpc.ts
@@ -12,7 +12,11 @@ const payloadPreprocessedSymbol = Symbol('Payload pre-processed by Magic SDK');
  * payloads we've already visited.
  */
 function markPayloadAsPreprocessed<T extends Partial<JsonRpcRequestPayload>>(payload: T): T {
-  (payload as any)[payloadPreprocessedSymbol] = true;
+  Object.defineProperty(payload, payloadPreprocessedSymbol, {
+    value: true,
+    enumerable: false,
+  });
+
   return payload;
 }
 
@@ -21,7 +25,7 @@ function markPayloadAsPreprocessed<T extends Partial<JsonRpcRequestPayload>>(pay
  * `standardizeJsonRpcRequestPayload(...)`.
  */
 function isPayloadPreprocessed<T extends Partial<JsonRpcRequestPayload>>(payload: T) {
-  return !!(payload as any)?.[payloadPreprocessedSymbol];
+  return !!(payload as any)[payloadPreprocessedSymbol];
 }
 
 /**

--- a/src/modules/base-module.ts
+++ b/src/modules/base-module.ts
@@ -3,6 +3,7 @@ import { createMalformedResponseError, MagicRPCError } from '../core/sdk-excepti
 import { PayloadTransport } from '../core/payload-transport';
 import { ViewController } from '../types/core/view-types';
 import { SDKBase } from '../core/sdk';
+import { standardizeJsonRpcRequestPayload } from '../core/json-rpc';
 
 export class BaseModule {
   constructor(protected readonly sdk: SDKBase) {}
@@ -19,7 +20,7 @@ export class BaseModule {
     const response = await this.transport.post<ResultType>(
       this.overlay,
       MagicOutgoingWindowMessage.MAGIC_HANDLE_REQUEST,
-      payload,
+      standardizeJsonRpcRequestPayload(payload),
     );
 
     if (response.hasError) throw new MagicRPCError(response.payload.error);

--- a/test/spec/core/json-rpc/standardizeJsonRpcRequestPayload.spec.ts
+++ b/test/spec/core/json-rpc/standardizeJsonRpcRequestPayload.spec.ts
@@ -53,3 +53,21 @@ test('Create a JSON RPC payload, replacing the missing value of `payload.params`
   const payload = standardizeJsonRpcRequestPayload({});
   t.deepEqual(payload.params, []);
 });
+
+test('Calling upon the same payload twice does not mutate the payload ID', t => {
+  const originalPayload = {
+    id: 999,
+  };
+
+  const randomIdStub = getPayloadIdStub();
+  randomIdStub.onFirstCall().returns(1);
+  randomIdStub.onSecondCall().returns(2);
+
+  standardizeJsonRpcRequestPayload(originalPayload);
+
+  t.is(originalPayload.id, 1);
+
+  standardizeJsonRpcRequestPayload(originalPayload);
+
+  t.is(originalPayload.id, 1);
+});


### PR DESCRIPTION
### 📦 Pull Request

Ethers V5 is using the newly standardized EIP1193 `request` interface, which was causing a conflict with our `BaseModule.request` method. Fortunately, our interface is already on-spec to EIP1193, but we were not doing our standard `payload.id` check on arguments passed to that method.

Testing coming soon!

### 🗜 Versioning

(Check _one!_)

- [x] Patch: Bug Fix?
- [ ] Minor: New Feature?
- [ ] Major: Breaking Change?

### ✅ Fixed Issues

- #88 

### 🚨 Test instructions

`yarn test`

### ⚠️ Update `CHANGELOG.md`

- [x] I have updated the `Upcoming Changes` section of `CHANGELOG.md` with context related to this Pull Request.
