### PR TITLE
Allow the Magic constructor to also reference the SDK instance type

### DIFF
--- a/react-native.d.ts
+++ b/react-native.d.ts
@@ -1,1 +1,1 @@
-export * from './dist/react-native/index.react-native.d.ts';
+export * from './dist/react-native/index.react-native';

--- a/src/index.cjs.ts
+++ b/src/index.cjs.ts
@@ -1,6 +1,7 @@
 // CJS entry-point
 
-export { MagicSDK as Magic } from './core/sdk';
+import { MagicSDK } from './core/sdk';
+
 export {
   MagicSDKError as SDKError,
   MagicSDKWarning as SDKWarning,
@@ -8,3 +9,6 @@ export {
 } from './core/sdk-exceptions';
 export { Extension } from './modules/base-extension';
 export * from './types';
+
+export const Magic = MagicSDK;
+export type Magic = InstanceType<typeof MagicSDK>;

--- a/src/index.react-native.ts
+++ b/src/index.react-native.ts
@@ -1,6 +1,8 @@
 // React Native entry-point
 /* eslint-disable global-require */
 
+import { MagicSDKReactNative } from './core/sdk';
+
 // We expect `global.process` to be a Node Process, so we have to replace it
 // here.
 global.process = require('process');
@@ -24,7 +26,6 @@ if (typeof atob === 'undefined') {
   };
 }
 
-export { MagicSDKReactNative as Magic } from './core/sdk';
 export {
   MagicSDKError as SDKError,
   MagicSDKWarning as SDKWarning,
@@ -32,3 +33,6 @@ export {
 } from './core/sdk-exceptions';
 export { Extension } from './modules/base-extension';
 export * from './types';
+
+export const Magic = MagicSDKReactNative;
+export type Magic = InstanceType<typeof MagicSDKReactNative>;


### PR DESCRIPTION
### 📦 Pull Request

It was difficult to get the instance type from the Magic constructor because of our extension wrapping types.

Before, you had to:

```ts
import { Magic } from 'magic-sdk';

const foo: InstanceType<typeof Magic> = new Magic(...);
```

Now, you can just:

```ts
import { Magic } from 'magic-sdk';

const foo: Magic = new Magic(...);
```

### 🗜 Versioning

(Check _one!_)

- [x] Patch: Bug Fix?
- [ ] Minor: New Feature?
- [ ] Major: Breaking Change?

### ✅ Fixed Issues

- Fixes #91 

### 🚨 Test instructions

`yarn test`

### ⚠️ Update `CHANGELOG.md`

- [ ] I have updated the `Upcoming Changes` section of `CHANGELOG.md` with context related to this Pull Request.
